### PR TITLE
Make package PEP 561 compliant

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,3 +43,6 @@ classifiers =
 packages = tinyflux
 python_requires = >=3.7
 
+[options.package_data]
+tinyflux =
+  "py.typed"


### PR DESCRIPTION
### Summary

This PR makes `tinyflux` package PEP 561 compliant.

### Closing issues

Closes #30 

### Semver update

A patch update is suggested for this PR since there are no alterations of the public API.
