### PR TITLE
Update Python support to 3.8-3.13 and fix decorator bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,11 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest]
         python-version:
-          ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9"]
+          ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }} on platform ${{ matrix.platform }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Assert no dependencies for TinyFlux
@@ -32,6 +32,6 @@ jobs:
       - name: Run tests
         run: coverage run --source tinyflux/ -m pytest && coverage report -m
       - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -10,11 +10,11 @@ jobs:
     name: Build and publish to PyPI and TestPyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
       - name: Install build
         run: |
           pip install --upgrade pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-  version: 3.8
+  version: 3.12
   install:
     - requirements: requirements.txt
     - method: pip

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
 
 TinyFlux is the tiny time series database optimized for your happiness 😎
 
-TinyFlux is the time series version of `TinyDB <https://tinydb.readthedocs.io/en/latest/index.html>`__ that is written in Python and has no external dependencies.  It's a great companion for small analytics workflows and apps, as well as at-home IOT data stores.  TinyFlux has 100% test coverage, over 75,000 downloads, and no open issues.
+TinyFlux is the time series version of `TinyDB <https://tinydb.readthedocs.io/en/latest/index.html>`__ that is written in Python and has no external dependencies.  It's a great companion for small analytics workflows and apps, as well as at-home IOT data stores.  TinyFlux has 100% test coverage, over 120,000 downloads, and no open issues.
 
 |Docs| |Version| |Downloads| |Coverage| |Build Status|
 
@@ -24,7 +24,7 @@ Quick Links
 Installation
 ************
 
-TinyFlux is hosted at `PyPI <https://pypi.org/project/tinyflux/>`__ and is easily downloadable with ``pip``. TinyFlux has been tested with Python 3.7 - 3.12 and PyPy-3.9 on Linux and Windows platforms.
+TinyFlux is hosted at `PyPI <https://pypi.org/project/tinyflux/>`__ and is easily downloadable with ``pip``. TinyFlux has been tested with Python 3.8 - 3.13 and PyPy-3.9 on Linux and Windows platforms.
 
 .. code-block:: bash
 
@@ -46,7 +46,7 @@ TinyFlux is:
 
 - **tiny:** TinyFlux is about 150kb, unzipped. The current source code has 4,000 lines of code (with about 50% documentation) and 4,000 lines of tests.  
 
-- **developed for modern Python:** TinyFlux works on all modern versions of Python (3.7 - 3.12) and PyPy (3.9).
+- **developed for modern Python:** TinyFlux works on all modern versions of Python (3.8 - 3.13) and PyPy (3.9).
 
 - **100% covered by tests:** No explanation needed.
 

--- a/docs/source/contributing-tooling.rst
+++ b/docs/source/contributing-tooling.rst
@@ -1,7 +1,7 @@
 Tooling and Conventions
 =======================
 
-TinyFlux should be developed locally with the latest stable version of Python on any platform  (3.10 as of this writing).
+TinyFlux should be developed locally with the latest stable version of Python on any platform  (3.13 as of this writing).
 
 
 Versioning

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,12 +29,12 @@ classifiers =
     Topic :: Database :: Database Engines/Servers
     Topic :: Utilities
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: OS Independent
@@ -42,7 +42,7 @@ classifiers =
 
 [options]
 packages = tinyflux
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.package_data]
 tinyflux = py.typed

--- a/tinyflux/decorators.py
+++ b/tinyflux/decorators.py
@@ -63,7 +63,7 @@ def temp_storage_op(method: Callable[..., Any]) -> Callable[..., Any]:
     """
 
     @wraps(method)
-    def op(self: Any, seprate=None, *args: Any, **kwargs: Any) -> Any:
+    def op(self: Any, *args: Any, **kwargs: Any) -> Any:
         """Decorate."""
         # Init temp storage in the storage class.
         self._storage._init_temp_storage()


### PR DESCRIPTION
- Remove Python 3.7 support, add Python 3.13 to CI/CD test matrix
- Update GitHub Actions to latest versions (checkout@v4, setup-python@v5, codecov@v4)
- Update package requirements to python_requires >= 3.8
- Add Python 3.13 classifier to setup.cfg
- Update all documentation references from 3.7-3.12 to 3.8-3.13
- Update download count from 75k to 120k+ in README
- Update ReadTheDocs Python version to 3.12
- Update contributing docs to reference Python 3.13 as latest
- Fix decorator bug: remove incorrect 'seprate' parameter from temp_storage_op

All tests pass with 100% coverage in Python 3.13.5 environment.